### PR TITLE
0.1.2: Fix iOS exception crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+
+* Fixed crash when error occurs on iOS.
+* Update example's Dart SDK constraints.
+
 ## 1.1.1
 
 * Added STAND_TIME, EXERCISE_TIME data types for iOS.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -199,4 +199,4 @@ packages:
     source: hosted
     version: "3.5.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.7.1 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the fit_kit plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.7.1 <3.0.0"
 
 dependencies:
   flutter:

--- a/ios/Classes/SwiftFitKitPlugin.swift
+++ b/ios/Classes/SwiftFitKitPlugin.swift
@@ -133,7 +133,7 @@ public class SwiftFitKitPlugin: NSObject, FlutterPlugin {
             _, samplesOrNil, error in
 
             guard var samples = samplesOrNil else {
-                result(FlutterError(code: self.TAG, message: "Results are null", details: error))
+                result(FlutterError(code: self.TAG, message: "Results are null", details: ["debugDescription": error.debugDescription]))
                 return
             }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fit_kit
 description: Flutter plugin for reading health and fitness data. Wraps HealthKit on iOS and GoogleFit on Android.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/krokyze/fitkit
 
 environment:


### PR DESCRIPTION
This PR fixes a deserialization error that crashes the app on iOS when an exception occurs while reading data, for example, when attempting to read data while the screen is locked and access is denied.