### PR TITLE
Throwing java.util.ConcurrentModificationException fix

### DIFF
--- a/android/src/main/kotlin/com/example/fit_kit/FitKitPlugin.kt
+++ b/android/src/main/kotlin/com/example/fit_kit/FitKitPlugin.kt
@@ -34,6 +34,7 @@ class FitKitPlugin(private val registrar: Registrar) : MethodCallHandler {
         registrar.addActivityResultListener { requestCode, resultCode, _ ->
             if (requestCode == GOOGLE_FIT_REQUEST_CODE) {
                 oAuthPermissionListeners.forEach { it.onOAuthPermissionsResult(resultCode) }
+                oAuthPermissionListeners.clear()
                 return@addActivityResultListener true
             }
             return@addActivityResultListener false
@@ -158,7 +159,6 @@ class FitKitPlugin(private val registrar: Registrar) : MethodCallHandler {
                 } else {
                     onError()
                 }
-                oAuthPermissionListeners.remove(this)
             }
         })
 


### PR DESCRIPTION
Removing an item from the list while iterating on it will throw:
Caused by: java.util.ConcurrentModificationException

if there's more than one item in the list:

![image](https://user-images.githubusercontent.com/6842786/77828737-307d6e80-7115-11ea-8a60-78e3bebbf755.png)
